### PR TITLE
Containerized the TRQP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ CORS_ORIGINS=["*"]
 # Logging Configuration
 LOG_LEVEL=INFO
 
+# NGROK Configuration for local development
+# To use ngrok for exposing local server, set the following:
+# NGROK_AUTH_TOKEN=your-ngrok-auth-token
+
 # ==========================================
 # Google OAuth Authentication Configuration
 # ==========================================
@@ -64,4 +68,5 @@ AUTHORIZED_EMAILS=your-email@example.com,another-admin@example.com
 # Secret key for session encryption
 # IMPORTANT: Generate a secure random string for production
 # You can generate one using: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# or by using: openssl rand -base64 32
 SECRET_KEY=change-this-to-a-random-secret-key-in-production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ trqp-ayra-fastapi/
 └── README.md                # This file
 ```
 
-## Installation
+## Local Installation (Option B only)
+
+If you're using **Quick Start Option A (Docker Compose)**, you can skip this section.
 
 ### Prerequisites
 - Python 3.9 or higher
 - pip
+
 
 ### Setup
 
@@ -97,8 +100,24 @@ cp .env.example .env
 ```
 
 ## Quick Start
+If you're using Option A, you do not need the Local Installation steps above.
 
-### 1. Run the Application
+### Option A: Run with Docker Compose
+
+1. Configure environment variables:
+```bash
+cp .env.example .env
+# Edit .env with your configuration
+```
+
+2. Start the services in the background:
+```bash
+docker-compose up -d
+```
+
+### Option B: Run Locally (Python)
+
+#### 1. Run the Application
 
 The application automatically initializes the database on startup.
 
@@ -117,7 +136,9 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
 ```
 
-### 2. Access the Application
+#### 2. Access the Application
+
+These URLs are the same whether you use Docker Compose or run locally.
 
 The application runs two separate APIs:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  trqp:
+    build:
+      context: .
+    ports:
+      - "8082:8000"
+    env_file:
+      - .env
+    volumes:
+      - trqp-data:/app
+    restart: unless-stopped
+  ngrok:
+    image: ngrok/ngrok:alpine
+    depends_on:
+      - trqp
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTH_TOKEN}
+    command: http --domain=sandbox-tr.ayra.network http://trqp:8000
+    restart: unless-stopped
+
+volumes:
+  trqp-data:


### PR DESCRIPTION
- Adds Docker Compose quick-start path for running the TRQP FastAPI service.
- Clarifies that local installation steps are only needed for the Python (Option B) flow.
- Aligns README guidance so containerized users can start with `docker-compose up -d` without extra setup.