### PR TITLE
added authentication to admin endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,23 @@ AUTHORIZED_EMAILS=your-email@example.com,another-admin@example.com
 # You can generate one using: python -c "import secrets; print(secrets.token_urlsafe(32))"
 # or by using: openssl rand -base64 32
 SECRET_KEY=change-this-to-a-random-secret-key-in-production
+
+# ==========================================
+# Optional Bearer-Token Admin Auth
+# ==========================================
+# Use one of the following approaches:
+#
+# 1) Static tokens (dev/test only):
+#    ADMIN_BEARER_TOKENS=token1,token2
+#
+# 2) JWT validation via JWKS (recommended):
+#    ADMIN_BEARER_JWKS_URL=https://idp.example.com/.well-known/jwks.json
+#    ADMIN_BEARER_ISSUER=https://idp.example.com/
+#    ADMIN_BEARER_AUDIENCE=trqp-admin
+#
+# When a Bearer token is provided, it is validated first. If no Bearer
+# token is provided, the admin UI cookie-based OAuth flow is used.
+ADMIN_BEARER_TOKENS=
+ADMIN_BEARER_JWKS_URL=
+ADMIN_BEARER_ISSUER=
+ADMIN_BEARER_AUDIENCE=

--- a/ADMIN_GUIDE.md
+++ b/ADMIN_GUIDE.md
@@ -96,7 +96,33 @@ http://localhost:8000/admin
 ```
 
 ### Authentication
-Currently, the admin API is open. In production, you should implement authentication and authorization.
+Admin endpoints require authentication. The **current/primary mode** used is static bearer tokens.
+
+#### Mode 1 (Primary): Static bearer tokens
+Set one or more tokens (comma-separated) in `.env`:
+```
+ADMIN_BEARER_TOKENS=token1,token2
+```
+
+Use the token in the `Authorization` header:
+```bash
+curl -H "Authorization: Bearer token1" http://localhost:8000/admin/entities
+```
+
+#### Mode 2: JWT/JWKS validation (optional)
+If you want JWT validation, set:
+```
+ADMIN_BEARER_JWKS_URL=https://issuer.example/.well-known/jwks.json
+ADMIN_BEARER_ISSUER=https://issuer.example/
+ADMIN_BEARER_AUDIENCE=trqp-admin
+```
+
+#### Swagger behind ngrok
+If you expose admin endpoints via ngrok, set:
+```
+EXTERNAL_URL=https://your-ngrok-domain.example
+```
+This updates the Swagger "Try it out" base URL.
 
 ### Endpoints
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,37 @@ The application runs two separate APIs:
 - **ReDoc**: http://localhost:8000/admin/redoc
 - **OpenAPI Spec**: http://localhost:8000/admin/openapi.json
 
+### Admin API Authentication (Required)
+
+The Admin UI and `/admin/*` endpoints require authentication. The **current/primary mode** used in local
+testing is **static bearer tokens** via `ADMIN_BEARER_TOKENS`.
+
+#### Mode 1 (Primary): Static bearer tokens
+Set one or more tokens (comma-separated) in `.env`:
+```
+ADMIN_BEARER_TOKENS=token1,token2
+```
+
+Call admin endpoints with:
+```bash
+curl -H "Authorization: Bearer token1" http://localhost:8000/admin/entities
+```
+
+#### Mode 2: JWT/JWKS validation (optional)
+If you want JWT validation, set:
+```
+ADMIN_BEARER_JWKS_URL=https://issuer.example/.well-known/jwks.json
+ADMIN_BEARER_ISSUER=https://issuer.example/
+ADMIN_BEARER_AUDIENCE=trqp-admin
+```
+
+#### Swagger behind ngrok
+If you expose the admin UI via ngrok, set:
+```
+EXTERNAL_URL=https://your-ngrok-domain.example
+```
+This updates the Swagger "Try it out" base URL.
+
 ### Database Initialization
 
 The database is automatically initialized on first run with:
@@ -306,9 +337,9 @@ See [LICENSE](LICENSE) file for details.
 
 * ✅ ~~Attach a back-end with real data to support sandbox use~~
 * ✅ ~~Add database integration (PostgreSQL/MongoDB)~~
-* Implement authentication and authorization for admin endpoints
+* ✅ ~~Implement authentication and authorization for admin endpoints~~
 * Add unit and integration tests
-* Add Docker containerization
+* ✅ ~~Add Docker containerization~~
 * Add CI/CD pipeline
 * Implement DID resolution
 * Add rate limiting

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -11,13 +11,13 @@ from pydantic import BaseModel, Field
 
 from app.database import get_db
 from app import crud
-from app.auth import get_current_user
+from app.auth import get_current_admin
 
 
 # Router with authentication dependency applied to all routes
 router = APIRouter(
     tags=["admin"],
-    dependencies=[Depends(get_current_user)]  # All routes require authentication
+    dependencies=[Depends(get_current_admin)]  # All routes require authentication
 )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,11 @@ services:
       - "8082:8000"
     env_file:
       - .env
+    environment:
+      DATABASE_URL: sqlite:////data/trqp.db
     volumes:
-      - trqp-data:/app
+      - .:/app
+      - trqp-data:/data
     restart: unless-stopped
   ngrok:
     image: ngrok/ngrok:alpine


### PR DESCRIPTION
## Summary
Adds admin API authentication support for the TRQP FastAPI service with a focus on **static bearer token auth** (used by CTS). Also documents how to configure admin auth and ngrok Swagger base URL.

## What’s Changed
- Added bearer token authentication for `/admin/*` endpoints
- Added optional JWT/JWKS validation configuration (issuer + audience)
- Updated admin router to accept bearer tokens and cookie-based auth
- Documented admin auth configuration + `EXTERNAL_URL` for Swagger behind ngrok

## Why
CTS needs to programmatically toggle authorizations in the Trust Registry during TRQP enforcement tests. The admin API must be protected while remaining easy to use in local/dev environments.

## How to Test
1) Configure `.env`:
   ```env
   ADMIN_BEARER_TOKENS=token1
   EXTERNAL_URL=https://sandbox-tr.ayra.network
   ```
2) Run:
   ```bash
   docker compose up --build -d
   ```
3) Verify:
   ```bash
   curl -H "Authorization: Bearer token1" http://localhost:8000/admin/entities
   ```
4) Confirm `/admin/docs` works when `EXTERNAL_URL` is set.

## Notes
- Primary auth mode for CTS is static bearer tokens (`ADMIN_BEARER_TOKENS`).
- JWT/JWKS mode is supported via `ADMIN_BEARER_JWKS_URL`, `ADMIN_BEARER_ISSUER`, `ADMIN_BEARER_AUDIENCE`.